### PR TITLE
Integrated loading from NUSMods fully, refactored getCode to getModuleCode

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -37,6 +37,7 @@ public class Duke {
         start(args);
         runCommandLoopUntilExitCommand();
         InputOutputManager.save();
+        InputOutputManager.saveNusMods();
     }
 
     /** Reads the user command and executes it, until the user issues the exit command.  */

--- a/src/main/java/seedu/duke/command/edit/EditModuleCommand.java
+++ b/src/main/java/seedu/duke/command/edit/EditModuleCommand.java
@@ -3,7 +3,6 @@ package seedu.duke.command.edit;
 import seedu.duke.command.CommandResult;
 import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
-import seedu.duke.directory.Directory;
 import seedu.duke.exception.ModuleNotProvidedException;
 import seedu.duke.parser.Parser;
 
@@ -47,7 +46,7 @@ public class EditModuleCommand extends EditCommand {
      */
 
     protected void edit(Module toEdit) throws ModuleManager.DuplicateModuleException, ModuleNotProvidedException {
-        toEdit.setCode(newModuleCode);
+        toEdit.setModuleCode(newModuleCode);
         ModuleManager.edit(toEdit, oldModuleCode);
     }
 

--- a/src/main/java/seedu/duke/data/Module.java
+++ b/src/main/java/seedu/duke/data/Module.java
@@ -4,22 +4,22 @@ import seedu.duke.directory.Directory;
 import seedu.duke.directory.DirectoryLevel;
 
 public class Module extends Directory {
-    private String code;
+    private String moduleCode;
     private String title;
 
     public Module() {
     }
 
-    public Module(String code) {
-        this.code = code;
+    public Module(String moduleCode) {
+        this.moduleCode = moduleCode;
     }
 
-    public String getCode() {
-        return code;
+    public String getModuleCode() {
+        return moduleCode;
     }
 
-    public void setCode(String code) {
-        this.code = code;
+    public void setModuleCode(String moduleCode) {
+        this.moduleCode = moduleCode;
     }
 
     public String getTitle() {
@@ -31,13 +31,13 @@ public class Module extends Directory {
     }
 
     public boolean isSameModule(Module checkModule) {
-        String moduleCode = checkModule.getCode();
+        String moduleCode = checkModule.getModuleCode();
         String moduleTitle = checkModule.getTitle();
-        return this.code.equalsIgnoreCase(moduleCode) && this.title.equalsIgnoreCase(moduleTitle);
+        return this.moduleCode.equalsIgnoreCase(moduleCode) && this.title.equalsIgnoreCase(moduleTitle);
     }
 
     public String toString() {
-        return getCode() + ": " + getTitle();
+        return getModuleCode() + ": " + getTitle();
     }
 
     @Override

--- a/src/main/java/seedu/duke/data/ModuleManager.java
+++ b/src/main/java/seedu/duke/data/ModuleManager.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 public class ModuleManager {
     private static HashMap<String, Module> modulesMap = new HashMap<>();
     // modulesMap is the main module list. Maps module code to module object.
-    private static final HashMap<String, Module> nusModsMap = new HashMap<>();
+    private static HashMap<String, Module> nusModsMap = new HashMap<>();
     // nusModsMap is the module list containing the Module objects created from NUSMods' JSON file of modules.
 
     /**
@@ -25,7 +25,7 @@ public class ModuleManager {
      */
     public static Module getModule(String moduleCode) throws ModuleNotFoundException {
         for (Module module : modulesMap.values()) {
-            if (module.getCode().equalsIgnoreCase(moduleCode)) {
+            if (module.getModuleCode().equalsIgnoreCase(moduleCode)) {
                 return module;
             }
         }
@@ -55,7 +55,7 @@ public class ModuleManager {
             throw new DuplicateModuleException();
         }
         modulesMap.remove(oldModuleCode);
-        modulesMap.put(newModule.getCode(), newModule);
+        modulesMap.put(newModule.getModuleCode(), newModule);
     }
 
     /**
@@ -80,10 +80,10 @@ public class ModuleManager {
      *  The module object to add to the module list
      */
     public static void add(Module newModule) throws DuplicateModuleException {
-        if (contains(newModule.getCode())) {
+        if (contains(newModule.getModuleCode())) {
             throw new DuplicateModuleException();
         }
-        modulesMap.put(newModule.getCode(), newModule);
+        modulesMap.put(newModule.getModuleCode(), newModule);
     }
 
     /**
@@ -105,10 +105,10 @@ public class ModuleManager {
      *  The module object to add to the module list
      */
     public static void addNusMod(Module newModule) throws DuplicateModuleException {
-        if (contains(newModule.getCode())) {
+        if (contains(newModule.getModuleCode())) {
             throw new DuplicateModuleException();
         }
-        nusModsMap.put(newModule.getCode(), newModule);
+        nusModsMap.put(newModule.getModuleCode(), newModule);
     }
 
     /**
@@ -123,7 +123,7 @@ public class ModuleManager {
      */
     public static Module getNusModule(String moduleCode) throws ModuleNotFoundException {
         for (Module module : nusModsMap.values()) {
-            if (module.getCode().equalsIgnoreCase(moduleCode)) {
+            if (module.getModuleCode().equalsIgnoreCase(moduleCode)) {
                 return module;
             }
         }
@@ -159,8 +159,17 @@ public class ModuleManager {
      *
      * @param loadedModulesMap the loaded module map from file
      */
-    public static void load(HashMap<String, Module> loadedModulesMap) {
+    public static void loadMods(HashMap<String, Module> loadedModulesMap) {
         modulesMap = loadedModulesMap;
+    }
+
+    /**
+     * Loads the file loaded module map into ModuleManager's own module map.
+     *
+     * @param loadedModulesMap the loaded module map from file
+     */
+    public static void loadNusMods(HashMap<String, Module> loadedModulesMap) {
+        nusModsMap = loadedModulesMap;
     }
 
     /**

--- a/src/main/java/seedu/duke/data/TaskManager.java
+++ b/src/main/java/seedu/duke/data/TaskManager.java
@@ -100,7 +100,7 @@ public class TaskManager {
      *
      * @param loadedTasksList the loaded task list from file
      */
-    public static void load(ArrayList<Task> loadedTasksList) {
+    public static void loadTasks(ArrayList<Task> loadedTasksList) {
         tasksList = loadedTasksList;
     }
 

--- a/src/main/java/seedu/duke/data/storage/Decoder.java
+++ b/src/main/java/seedu/duke/data/storage/Decoder.java
@@ -30,12 +30,19 @@ import seedu.duke.ui.TextUi;
  * @author Wang Qin
  */
 public class Decoder {
-
+    /**
+     * Loads a HashMap of Module objects from the specified file. Used for both user and NUS modules.
+     *
+     * @param
+     *  dataFileName The file to load from
+     * @return
+     *  The HashMap of Module objects
+     */
     public static HashMap<String, Module> loadModules(String dataFileName) {
         String jsonStr;
         jsonStr = loadJsonStringFromFile(dataFileName);
         TextUi.outputToUser(dataFileName);
-        // FastJSON doesn't write the square brackets for some reason, so we add it in here
+        // FastJSON doesn't write the square brackets for some reason when we save, so we add it in here
         // so that parseArray works as it should
         if (jsonStr != null) {
             jsonStr = "[" + jsonStr + "]";
@@ -63,7 +70,7 @@ public class Decoder {
     public static ArrayList<Task> loadTasks(String dataFileName) {
         String jsonStr;
         jsonStr = loadJsonStringFromFile(dataFileName);
-        // FastJSON doesn't write the square brackets for some reason, so we add it in here
+        // FastJSON doesn't write the square brackets for some reason when we save, so we add it in here
         // so that parseArray works as it should
         if (jsonStr != null) {
             jsonStr = "[" + jsonStr + "]";
@@ -72,10 +79,17 @@ public class Decoder {
         return new ArrayList<>(tasksList);
     }
 
+    /**
+     * Pulls JSON from the NUSMods API, parses it, and returns the HashMap of Module objects.
+     *
+     * @return
+     *  The HashMap of Module objects (from NUSMods)
+     */
     public static HashMap<String, Module> generateNusModsList() {
         HashMap<String, Module> retrievedNusModsList = new HashMap<>();
         String retrievedJson;
         retrievedJson = requestNusModsJsonString("https://api.nusmods.com/v2/2019-2020/moduleList.json");
+        // This JSON string comes with the square brackets, so no need to add
         List<Module> modulesList = JSON.parseArray(retrievedJson, Module.class);// extractModules(jsonStr);
 
         for (Module eachModule : modulesList) {
@@ -85,7 +99,14 @@ public class Decoder {
         return retrievedNusModsList;
     }
 
-
+    /**
+     * Reads a string from a file (doesn't necessarily have to be JSON).
+     *
+     * @param dataFileName
+     *  The specified file
+     * @return
+     *  The string read from file
+     */
     private static String loadJsonStringFromFile(String dataFileName) {
         File file = new File(dataFileName);
         long fileLength = file.length();

--- a/src/main/java/seedu/duke/data/storage/Decoder.java
+++ b/src/main/java/seedu/duke/data/storage/Decoder.java
@@ -76,9 +76,6 @@ public class Decoder {
         HashMap<String, Module> retrievedNusModsList = new HashMap<>();
         String retrievedJson;
         retrievedJson = requestNusModsJsonString("https://api.nusmods.com/v2/2019-2020/moduleList.json");
-        if (retrievedJson != null) {
-            retrievedJson = retrievedJson ;
-        }
         List<Module> modulesList = JSON.parseArray(retrievedJson, Module.class);// extractModules(jsonStr);
 
         for (Module eachModule : modulesList) {

--- a/src/main/java/seedu/duke/data/storage/Decoder.java
+++ b/src/main/java/seedu/duke/data/storage/Decoder.java
@@ -44,7 +44,7 @@ public class Decoder {
         HashMap<String, Module> modulesMap = new HashMap<>();
         if (moduleList != null) {
             for (Module eachModule : moduleList) {
-                modulesMap.put(eachModule.getCode(), eachModule);
+                modulesMap.put(eachModule.getModuleCode(), eachModule);
             }
         }
         return modulesMap;
@@ -60,7 +60,7 @@ public class Decoder {
      * @throws FileNotFoundException
      *  When the file does not exist
      */
-    public static ArrayList<Task> loadTasks(String dataFileName) throws FileNotFoundException {
+    public static ArrayList<Task> loadTasks(String dataFileName) {
         String jsonStr;
         jsonStr = loadJsonStringFromFile(dataFileName);
         // FastJSON doesn't write the square brackets for some reason, so we add it in here
@@ -70,6 +70,22 @@ public class Decoder {
         }
         List<Task> tasksList = JSON.parseArray(jsonStr, Task.class);// extractModules(jsonStr);
         return new ArrayList<>(tasksList);
+    }
+
+    public static HashMap<String, Module> generateNusModsList() {
+        HashMap<String, Module> retrievedNusModsList = new HashMap<>();
+        String retrievedJson;
+        retrievedJson = requestNusModsJsonString("https://api.nusmods.com/v2/2019-2020/moduleList.json");
+        if (retrievedJson != null) {
+            retrievedJson = retrievedJson ;
+        }
+        List<Module> modulesList = JSON.parseArray(retrievedJson, Module.class);// extractModules(jsonStr);
+
+        for (Module eachModule : modulesList) {
+            retrievedNusModsList.put(eachModule.getModuleCode(), eachModule);
+        }
+
+        return retrievedNusModsList;
     }
 
 
@@ -82,9 +98,6 @@ public class Decoder {
             FileInputStream in = new FileInputStream(file);
             in.read(fileContent);
             in.close();
-        } catch (FileNotFoundException e) {
-            // System.out.println("Retrieving the module list from nusmods...");
-            // return requestNusModsJsonString("https://api.nusmods.com/v2/2019-2020/moduleList.json");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -108,6 +121,7 @@ public class Decoder {
      *  The JSON string with information of all currently available mods in NUS.
      */
     private static String requestNusModsJsonString(String filePath) {
+        System.out.println("Getting stuff from NUSMods");
         int httpResult; // the status from the server response
         String content = "";
         try {

--- a/src/main/java/seedu/duke/data/storage/Decoder.java
+++ b/src/main/java/seedu/duke/data/storage/Decoder.java
@@ -29,12 +29,13 @@ import seedu.duke.ui.TextUi;
  * @author Sim Jun You
  * @author Wang Qin
  */
+
 public class Decoder {
     /**
      * Loads a HashMap of Module objects from the specified file. Used for both user and NUS modules.
      *
-     * @param
-     *  dataFileName The file to load from
+     * @param dataFileName
+     *  The file to load from
      * @return
      *  The HashMap of Module objects
      */

--- a/src/main/java/seedu/duke/data/storage/Encoder.java
+++ b/src/main/java/seedu/duke/data/storage/Encoder.java
@@ -45,6 +45,7 @@ public class Encoder {
         File mySaveFile = new File(dataFileName);
         prepareSaveFile(mySaveFile);
         Module currentModule;
+        String[] modsToBeSaved = ModuleManager.getModCodeList();
         for (String eachModCode : ModuleManager.getModCodeList()) {
             currentModule = ModuleManager.getModule(eachModCode);
             writeToFile(mySaveFile, JSON.toJSONString(currentModule));

--- a/src/main/java/seedu/duke/data/storage/InputOutputManager.java
+++ b/src/main/java/seedu/duke/data/storage/InputOutputManager.java
@@ -2,15 +2,13 @@ package seedu.duke.data.storage;
 
 import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
-import seedu.duke.data.Task;
 import seedu.duke.common.Constant;
 import seedu.duke.data.TaskManager;
-import seedu.duke.ui.TextUi;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.nio.file.Files;
 import java.util.HashMap;
 
 /**
@@ -21,8 +19,6 @@ import java.util.HashMap;
  * @author Sim Jun You
  */
 public class InputOutputManager {
-    static ArrayList<Task> loadedTasksList;
-    static HashMap<String, Module> loadedModulesMap;
     static HashMap<String, Module> loadedNusModulesMap;
 
     static String root = System.getProperty("user.dir");
@@ -44,27 +40,31 @@ public class InputOutputManager {
         if (!saveFolder.exists()) {
             saveFolder.mkdir();
         } else {
-            loadUserSaves();
+            if (Files.exists(userModuleFile) && Files.exists(userTaskFile)) {
+                loadUserSaves();
+            }
+            loadNusModSave(); // loads from NUSMods API if file not found
         }
+
     }
 
     /**
      * Loads user saves (modules, tasks) from the given files.
      */
     public static void loadUserSaves() {
-        try {
-            ModuleManager.load(Decoder.loadModules(userModuleFile.toString()));
-            TaskManager.load(Decoder.loadTasks(userTaskFile.toString()));
-        } catch (FileNotFoundException e) {
-            // do nothing
-        }
+        ModuleManager.loadMods(Decoder.loadModules(userModuleFile.toString()));
+        TaskManager.loadTasks(Decoder.loadTasks(userTaskFile.toString()));
     }
 
     /**
      * Loads NUS Modules from the given file.
      */
     public static void loadNusModSave() {
-        loadedNusModulesMap = Decoder.loadModules(nusModuleFileName);
+        if (!Files.exists(nusModuleFile)) {
+            ModuleManager.loadNusMods(Decoder.generateNusModsList());
+        } else {
+            ModuleManager.loadNusMods(Decoder.loadModules(nusModuleFile.toString()));
+        }
     }
 
     /**
@@ -72,8 +72,12 @@ public class InputOutputManager {
      */
     public static void save() {
         try {
-            Encoder.saveModules(userModuleFile.toString());
-            Encoder.saveTasks(userTaskFile.toString());
+            if (ModuleManager.getModCodeList().length != 0) {
+                Encoder.saveModules(userModuleFile.toString());
+            }
+            if (TaskManager.getTaskCount() != 0) {
+                Encoder.saveTasks(userTaskFile.toString());
+            }
         } catch (ModuleManager.ModuleNotFoundException e) {
             // print module not found
         } catch (TaskManager.TaskNotFoundException e) {

--- a/src/main/java/seedu/duke/data/storage/InputOutputManager.java
+++ b/src/main/java/seedu/duke/data/storage/InputOutputManager.java
@@ -19,8 +19,6 @@ import java.util.HashMap;
  * @author Sim Jun You
  */
 public class InputOutputManager {
-    static HashMap<String, Module> loadedNusModulesMap;
-
     static String root = System.getProperty("user.dir");
     static java.nio.file.Path dirPath = java.nio.file.Paths.get(root, "data");
 

--- a/src/test/java/seedu/duke/data/ModuleTest.java
+++ b/src/test/java/seedu/duke/data/ModuleTest.java
@@ -36,9 +36,9 @@ public class ModuleTest {
     @Test
     void getModule_isCorrect() throws ModuleManager.ModuleNotFoundException {
         assertEquals(normalMod1.getTitle(), ModuleManager.getModule(MOD_CODE_1).getTitle());
-        assertEquals(normalMod1.getCode(), ModuleManager.getModule(MOD_CODE_1).getCode());
+        assertEquals(normalMod1.getModuleCode(), ModuleManager.getModule(MOD_CODE_1).getModuleCode());
         assertEquals(normalMod2.getTitle(), ModuleManager.getModule(MOD_CODE_2).getTitle());
-        assertEquals(normalMod2.getCode(), ModuleManager.getModule(MOD_CODE_2).getCode());
+        assertEquals(normalMod2.getModuleCode(), ModuleManager.getModule(MOD_CODE_2).getModuleCode());
     }
 
     @Test


### PR DESCRIPTION
Added the line `InputOutputManager.saveNusMods();` to Duke.java to fully integrate saving/loading of NUSMods data.

Flow:
- When program starts, if nus_mods_data.json is not found in the data folder, it will retrieve JSON from NUSMods API and load it into `nusModulesList` in ModuleManager.
- If nus_mods_data.json is found, then it will retrieve JSON from there instead and do the same as above.
- After program completes (`bye`), it will call `InputOutputManager.saveNusMods()` to save the `nusModulesList` to disk just like `InputOutputManager.save()` does for user task/mod lists.

Currently still no checking of user mod list against NUS mod list.

Refactored `getCode` method of the Module class to `getModuleCode` (and same for `setCode`) to allow FastJSON to parse NUSMods JSON objects directly to Module objects. 