### PR TITLE
Added DukeLogger class and added its setup in main Duke class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ src/main/resources/docs/
 *.iml
 bin/
 
+# Project specific
 /text-ui-test/ACTUAL.txt
-text-ui-test/EXPECTED-UNIX.TXT
+/text-ui-test/EXPECTED-UNIX.TXT
+/data/
+/logs/

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -9,9 +9,12 @@ import seedu.duke.ui.TextUi;
 
 import java.io.FileNotFoundException;
 import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Duke {
     private TextUi ui;
+    private static final DukeLogger logger = new DukeLogger(Duke.class.getName());
 
     /**
      * Entry-point for the java.duke.Duke application.
@@ -26,25 +29,26 @@ public class Duke {
     /** Sets up the storage, loads up the data from the storage file and prints the welcome message.  */
     private void start(String[] args) throws FileNotFoundException {
         Scanner in = new Scanner(System.in);
-        DukeLogger.setup(Duke.class.getName());
         this.ui = new TextUi(in);
         InputOutputManager.start();
         ui.showWelcomeMessage();
-        DukeLogger.info("Initialised scanner, logger, UI, and IO");
+        logger.getLogger().info("Initialised scanner, UI, and IO");
     }
 
     /** Runs the program until termination.  */
     public void run(String[] args) throws FileNotFoundException {
+        logger.getLogger().info("STARTING PROGRAM...");
         start(args);
         runCommandLoopUntilExitCommand();
         InputOutputManager.save();
         InputOutputManager.saveNusMods();
+        logger.getLogger().info("PROGRAM TERMINATED SUCCESSFULLY");
     }
 
     /** Reads the user command and executes it, until the user issues the exit command.  */
     private void runCommandLoopUntilExitCommand() {
         Command command;
-        DukeLogger.info("Entering command loop...");
+        logger.getLogger().info("ENTERING COMMAND LOOP");
         do {
             String userInput = ui.getUserCommand();
             command = new Parser().parseCommand(userInput);

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -26,10 +26,11 @@ public class Duke {
     /** Sets up the storage, loads up the data from the storage file and prints the welcome message.  */
     private void start(String[] args) throws FileNotFoundException {
         Scanner in = new Scanner(System.in);
+        DukeLogger.setup(Duke.class.getName());
         this.ui = new TextUi(in);
-        // todo add code to the following functions in InputOutputManager, TextUi
         InputOutputManager.start();
         ui.showWelcomeMessage();
+        DukeLogger.info("Initialised scanner, logger, UI, and IO");
     }
 
     /** Runs the program until termination.  */
@@ -43,6 +44,7 @@ public class Duke {
     /** Reads the user command and executes it, until the user issues the exit command.  */
     private void runCommandLoopUntilExitCommand() {
         Command command;
+        DukeLogger.info("Entering command loop...");
         do {
             String userInput = ui.getUserCommand();
             command = new Parser().parseCommand(userInput);

--- a/src/main/java/seedu/duke/DukeLogger.java
+++ b/src/main/java/seedu/duke/DukeLogger.java
@@ -1,13 +1,89 @@
 package seedu.duke;
 
-//import seedu.duke.command.add.AddModuleCommand;
-
+import java.io.IOException;
+import java.util.logging.FileHandler;
 import java.util.logging.Logger;
+import java.util.logging.Level;
+import java.util.logging.SimpleFormatter;
+import java.io.File;
 
 public class DukeLogger {
-//    private static Logger logger = Logger.getLogger(AddModuleCommand.class.getName());
-//
-//    public static Logger getLogger() {
-//        return logger;
-//    }
+    private static Logger dukeLogger;
+    private static FileHandler logFile;
+    private static SimpleFormatter formatterTxt = new SimpleFormatter();
+    private static final String logPath = "./logs/";
+    private static final String logName = "session_";
+    private static final String logExt = ".log";
+    private static final Level loggingLevel = Level.INFO; // CHANGE LOGGING LEVEL HERE!
+
+    public static void setup(String className) {
+        try {
+            preparePath();
+            String currentLogFile = prepareFile();
+            dukeLogger = Logger.getLogger(className);
+            logFile = new FileHandler(currentLogFile); // todo: remove magic file path
+            dukeLogger.setUseParentHandlers(false); // Stop it from logging from console...
+            logFile.setFormatter(formatterTxt);
+            dukeLogger.addHandler(logFile); // Make it log to file instead
+            dukeLogger.setLevel(loggingLevel);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void info(String log) {
+        dukeLogger.info(log);
+    }
+
+    public static void info(String log, Exception e) {
+        dukeLogger.log(Level.INFO, log, e);
+    }
+
+    public static void info(String log, Object ob) {
+        dukeLogger.log(Level.INFO, log, ob);
+    }
+
+    public static void warning(String log) {
+        dukeLogger.warning(log);
+    }
+
+    public static void warning(String log, Exception e) {
+        dukeLogger.log(Level.WARNING, log, e);
+    }
+
+    public static void warning(String log, Object ob) {
+        dukeLogger.log(Level.WARNING, log, ob);
+    }
+
+    public static void severe(String log) {
+        dukeLogger.severe(log);
+    }
+
+    public static void severe(String log, Exception e) {
+        dukeLogger.log(Level.SEVERE, log, e);
+    }
+
+    public static void severe(String log, Object ob) {
+        dukeLogger.log(Level.SEVERE, log, ob);
+    }
+
+    public static void preparePath() {
+        File logFolder = new File(logPath);
+        if (!logFolder.exists()) {
+            logFolder.mkdir();
+        }
+    }
+
+    public static String prepareFile() throws IOException {
+        int sessionNum = 1;
+        String currentLogFileName = logPath + logName + sessionNum + logExt;
+        File logFile = new File(currentLogFileName);
+        while (logFile.exists()) {
+            sessionNum++;
+            currentLogFileName = logPath + logName + sessionNum + logExt;
+            logFile = new File(currentLogFileName);
+        }
+        logFile.createNewFile();
+        return currentLogFileName;
+    }
 }

--- a/src/main/java/seedu/duke/DukeLogger.java
+++ b/src/main/java/seedu/duke/DukeLogger.java
@@ -11,10 +11,10 @@ public class DukeLogger {
     private static Logger dukeLogger;
     private static FileHandler logFile;
     private static SimpleFormatter formatterTxt = new SimpleFormatter();
-    private static final String logPath = "./logs/";
-    private static final String logName = "session_";
-    private static final String logExt = ".log";
-    private static final Level loggingLevel = Level.INFO; // CHANGE LOGGING LEVEL HERE!
+    private static final String LOG_PATH = "./logs/";
+    private static final String LOG_NAME = "session_";
+    private static final String LOG_EXT = ".log";
+    private static final Level LOGGING_LEVEL = Level.INFO; // CHANGE LOGGING LEVEL HERE!
 
     public static void setup(String className) {
         try {
@@ -25,7 +25,7 @@ public class DukeLogger {
             dukeLogger.setUseParentHandlers(false); // Stop it from logging from console...
             logFile.setFormatter(formatterTxt);
             dukeLogger.addHandler(logFile); // Make it log to file instead
-            dukeLogger.setLevel(loggingLevel);
+            dukeLogger.setLevel(LOGGING_LEVEL);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -68,7 +68,7 @@ public class DukeLogger {
     }
 
     public static void preparePath() {
-        File logFolder = new File(logPath);
+        File logFolder = new File(LOG_PATH);
         if (!logFolder.exists()) {
             logFolder.mkdir();
         }
@@ -76,11 +76,11 @@ public class DukeLogger {
 
     public static String prepareFile() throws IOException {
         int sessionNum = 1;
-        String currentLogFileName = logPath + logName + sessionNum + logExt;
+        String currentLogFileName = LOG_PATH + LOG_NAME + sessionNum + LOG_EXT;
         File logFile = new File(currentLogFileName);
         while (logFile.exists()) {
             sessionNum++;
-            currentLogFileName = logPath + logName + sessionNum + logExt;
+            currentLogFileName = LOG_PATH + LOG_NAME + sessionNum + LOG_EXT;
             logFile = new File(currentLogFileName);
         }
         logFile.createNewFile();

--- a/src/main/java/seedu/duke/data/TaskManager.java
+++ b/src/main/java/seedu/duke/data/TaskManager.java
@@ -4,6 +4,7 @@ import seedu.duke.exception.DataNotFoundException;
 import seedu.duke.ui.TextUi;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 
 public class TaskManager {
     private static ArrayList<Task> tasksList = new ArrayList<>(); // Main task list.
@@ -70,6 +71,41 @@ public class TaskManager {
         }
         task = getTask(taskId);
         task.setStatus();
+    }
+
+    /**
+     * Generate an ordered ArrayList of ArrayLists.
+     * First ArrayList contains a list of uncompleted tasks with deadlines, sorted by deadlines.
+     * Second ArrayList contains a list of uncompleted tasks without deadlines.
+     * Last ArrayList contains a list of completed tasks.
+     *
+     * @return
+     *  The ArrayList of ArrayLists mentioned above.
+     */
+    public static ArrayList<ArrayList<Task>> summary() {
+        ArrayList<ArrayList<Task>> summaryLists = new ArrayList<>();
+        ArrayList<Task> incompleteTasksDated = new ArrayList<>();
+        ArrayList<Task> incompleteTasksUndated = new ArrayList<>();
+        ArrayList<Task> completedTasks = new ArrayList<>();
+
+        for (Task eachTask : tasksList) {
+            if (eachTask.getStatus()) {
+                completedTasks.add(eachTask);
+            } else if (eachTask.getDeadline() == null) {
+                incompleteTasksUndated.add(eachTask);
+            } else {
+                incompleteTasksDated.add(eachTask);
+            }
+        }
+
+        Comparator<Task> compareByDeadline = Comparator.comparing(Task::getDeadline);
+        incompleteTasksDated.sort(compareByDeadline);
+
+        // Do not change the adding order!
+        summaryLists.add(incompleteTasksDated);
+        summaryLists.add(incompleteTasksUndated);
+        summaryLists.add(completedTasks);
+        return summaryLists;
     }
 
     /**

--- a/src/main/java/seedu/duke/data/storage/Decoder.java
+++ b/src/main/java/seedu/duke/data/storage/Decoder.java
@@ -42,7 +42,6 @@ public class Decoder {
     public static HashMap<String, Module> loadModules(String dataFileName) {
         String jsonStr;
         jsonStr = loadJsonStringFromFile(dataFileName);
-        TextUi.outputToUser(dataFileName);
         // FastJSON doesn't write the square brackets for some reason when we save, so we add it in here
         // so that parseArray works as it should
         if (jsonStr != null) {

--- a/src/main/java/seedu/duke/data/storage/Decoder.java
+++ b/src/main/java/seedu/duke/data/storage/Decoder.java
@@ -140,7 +140,6 @@ public class Decoder {
      *  The JSON string with information of all currently available mods in NUS.
      */
     private static String requestNusModsJsonString(String filePath) {
-        System.out.println("Getting stuff from NUSMods");
         int httpResult; // the status from the server response
         String content = "";
         try {

--- a/src/main/java/seedu/duke/data/storage/InputOutputManager.java
+++ b/src/main/java/seedu/duke/data/storage/InputOutputManager.java
@@ -1,16 +1,16 @@
 package seedu.duke.data.storage;
 
-import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
 import seedu.duke.common.Constant;
 import seedu.duke.data.TaskManager;
 import seedu.duke.DukeLogger;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.HashMap;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Manages all inputs and outputs (to and from files).
@@ -30,13 +30,17 @@ public class InputOutputManager {
     static java.nio.file.Path userTaskFile = java.nio.file.Paths.get(String.valueOf(dirPath), userTaskFileName);
     static java.nio.file.Path nusModuleFile = java.nio.file.Paths.get(String.valueOf(dirPath), nusModuleFileName);
 
+    private static final DukeLogger logger = new DukeLogger(InputOutputManager.class.getName());
+
     /**
      * Creates the save directory if it has not been created.
      * Loads the user's module and task saves into memory.
      */
     public static void start() {
+        logger.getLogger().info("Starting InputOutputManager");
         File saveFolder = dirPath.toFile();
         if (!saveFolder.exists()) {
+            logger.getLogger().info("Save folder does not exist, creating now");
             saveFolder.mkdir();
         } else {
             if (Files.exists(userModuleFile) && Files.exists(userTaskFile)) {
@@ -44,13 +48,13 @@ public class InputOutputManager {
             }
             loadNusModSave(); // loads from NUSMods API if file not found
         }
-
     }
 
     /**
      * Loads user saves (modules, tasks) from the given files.
      */
     public static void loadUserSaves() {
+        logger.getLogger().info("Loading user saves from " + userModuleFileName + " and " + userTaskFileName);
         ModuleManager.loadMods(Decoder.loadModules(userModuleFile.toString()));
         TaskManager.loadTasks(Decoder.loadTasks(userTaskFile.toString()));
     }
@@ -59,6 +63,7 @@ public class InputOutputManager {
      * Loads NUS Modules from the given file.
      */
     public static void loadNusModSave() {
+        logger.getLogger().info("Loading NUS Modules from " + nusModuleFileName);
         if (!Files.exists(nusModuleFile)) {
             ModuleManager.loadNusMods(Decoder.generateNusModsList());
         } else {
@@ -70,6 +75,7 @@ public class InputOutputManager {
      * Updates the user's save files. Does not save NUS Modules.
      */
     public static void save() {
+        logger.getLogger().info("Saving user modules and tasks into " + userModuleFileName + " and " + userTaskFileName);
         try {
             if (ModuleManager.getModCodeList().length != 0) {
                 Encoder.saveModules(userModuleFile.toString());
@@ -78,11 +84,13 @@ public class InputOutputManager {
                 Encoder.saveTasks(userTaskFile.toString());
             }
         } catch (ModuleManager.ModuleNotFoundException e) {
+            logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
             // print module not found
         } catch (TaskManager.TaskNotFoundException e) {
+            logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
             // print task not found
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
         }
     }
 
@@ -90,11 +98,14 @@ public class InputOutputManager {
      * Updates the user's NUS Modules save file.
      */
     public static void saveNusMods() {
+        logger.getLogger().info("Saving NUS modules into " + nusModuleFileName);
         try {
             Encoder.saveNusModules(nusModuleFile.toString());
         } catch (ModuleManager.ModuleNotFoundException e) {
+            logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
             // print module not found
         } catch (IOException e) {
+            logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
             e.printStackTrace();
         }
     }

--- a/src/main/java/seedu/duke/data/storage/InputOutputManager.java
+++ b/src/main/java/seedu/duke/data/storage/InputOutputManager.java
@@ -75,7 +75,8 @@ public class InputOutputManager {
      * Updates the user's save files. Does not save NUS Modules.
      */
     public static void save() {
-        logger.getLogger().info("Saving user modules and tasks into " + userModuleFileName + " and " + userTaskFileName);
+        logger.getLogger().info("Saving user modules and tasks into " + userModuleFileName
+                + " and " + userTaskFileName);
         try {
             if (ModuleManager.getModCodeList().length != 0) {
                 Encoder.saveModules(userModuleFile.toString());

--- a/src/main/java/seedu/duke/data/storage/InputOutputManager.java
+++ b/src/main/java/seedu/duke/data/storage/InputOutputManager.java
@@ -4,6 +4,7 @@ import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
 import seedu.duke.common.Constant;
 import seedu.duke.data.TaskManager;
+import seedu.duke.DukeLogger;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/test/java/seedu/duke/data/TaskTest.java
+++ b/src/test/java/seedu/duke/data/TaskTest.java
@@ -4,8 +4,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TaskTest {
@@ -52,5 +55,36 @@ class TaskTest {
 
         assertEquals(0, TaskManager.getTaskCount());
         assertThrows(TaskManager.TaskNotFoundException.class, () -> TaskManager.getTask(0));
+    }
+
+    @Test
+    void summary_checkTaskOrder_isCorrect() {
+        LocalDateTime myDate = LocalDateTime.of(2020, 10, 1, 1, 0);
+        Task laterDatedTask = new Task("LATER", myDate);
+        TaskManager.add(laterDatedTask);
+
+        ArrayList<Task> sortedTaskWithDeadlines = TaskManager.summary().get(0);
+        Task earlierTask = sortedTaskWithDeadlines.get(0);
+        Task laterTask = sortedTaskWithDeadlines.get(1);
+        // Assert that laterTask actually has a later deadline than earlierTask
+        assertTrue(laterTask.getDeadline().compareTo(earlierTask.getDeadline()) > 0);
+        assertEquals(2, sortedTaskWithDeadlines.size());
+    }
+
+    @Test
+    void summary_checkNoDeadlineList_isCorrect() {
+        ArrayList<Task> sortedTasksWithoutDeadlines = TaskManager.summary().get(1);
+        Task taskWithoutDeadline = sortedTasksWithoutDeadlines.get(0);
+        assertTrue(taskWithoutDeadline.getDeadline() == null);
+        assertEquals(1, sortedTasksWithoutDeadlines.size());
+    }
+
+    @Test
+    void summary_checkCompletedList_isCorrect() throws TaskManager.TaskNotFoundException {
+        TaskManager.done(0);
+        TaskManager.done(1);
+        ArrayList<Task> completedTasks = TaskManager.summary().get(2);
+        assertTrue(completedTasks.get(0).getStatus());
+        assertEquals(2, completedTasks.size());
     }
 }


### PR DESCRIPTION
### DukeLogger
The DukeLogger class is static and encapsulates the builtin Java logger to perform all setup in one class.

`setup()` is called in Duke class, in the `start()` method. It only needs to be called once, and it will prepare the log directory and log file and configure the logger. Some basic logging is done in the Duke class as an example.

All logs are saved to `./logs`. Each log file is named session_n.log where n starts from 1 and will increment for the latest run if the previous files are not deleted. e.g. if session_1.log exists, then the next program run will create a session_2.log and log in there.

### Using DukeLogger
1. Import DukeLogger. `import seedu.duke.DukeLogger`
2. Initialise it and provide your class name. Example: `private static final DukeLogger logger = new DukeLogger(Duke.class.getName());`
3. To log, use `logger.getLogger()` and then any of the [logging methods](https://docs.oracle.com/en/java/javase/11/docs/api/java.logging/java/util/logging/Logger.html) (see All Methods).

Generally, `info()`, `warning()`, and `severe()` are used if there is **only a message**. e.g. `info(logMessage)`
But if you want to **pass an exception or object/objects** into the logger, you must use `log()`:
- Log a message, with associated Throwable information:
  - `log​(Level level, String msg, Throwable thrown)`
- Log a message, with one object parameter:
  - `log​(Level level, String msg, Object param1)`
- Log a message, with an array of object arguments:
  - `log​(Level level, String msg, Object[] params)`

You must also import Level (`import java.util.logging.Level`), an enum for the priority of the log. e.g. `Level.INFO`, `Level.WARNING`, etc.

The logger's level is set within DukeLogger by a constant `LOGGING_LEVEL` that is currently set at `INFO`. There is no method to change the logger's level during runtime.

Also, updated .gitignore to ignore /data and /logs.