### PR TITLE
Added Lesson classes and basic 'timetable' functionality

### DIFF
--- a/src/main/java/seedu/duke/data/Lesson.java
+++ b/src/main/java/seedu/duke/data/Lesson.java
@@ -1,20 +1,26 @@
 package seedu.duke.data;
 
+import seedu.duke.exception.LessonInvalidTimeException;
+
 import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 public class Lesson {
-    private Module module;
+    private String moduleCode;
     private String description;
     private LessonType lessonType;
     private DayOfWeek day;
     private LocalTime startTime;
     private LocalTime endTime;
 
-    public Lesson(Module module, LessonType lessonType, DayOfWeek day, LocalTime startTime, LocalTime endTime) {
-        this.module = module;
+    public Lesson(String moduleCode, LessonType lessonType, DayOfWeek day, LocalTime startTime, LocalTime endTime)
+            throws LessonInvalidTimeException {
+        if (startTime.isAfter(endTime) || startTime.equals(endTime)) {
+            throw new LessonInvalidTimeException();
+        }
+
+        this.moduleCode = moduleCode;
         this.lessonType = lessonType;
         this.day = day;
         this.startTime = startTime;
@@ -29,6 +35,10 @@ public class Lesson {
         return description;
     }
 
+    public String getModuleCode() {
+        return moduleCode;
+    }
+
     public LocalTime getStartTime() {
         return startTime;
     }
@@ -39,6 +49,14 @@ public class Lesson {
 
     public DayOfWeek getDay() {
         return day;
+    }
+
+    public boolean isAfter(Lesson otherLesson) {
+        return otherLesson.getEndTime().isBefore(startTime) || otherLesson.getEndTime().equals(startTime);
+    }
+
+    public boolean isBefore(Lesson otherLesson) {
+        return otherLesson.getStartTime().isAfter(endTime) || otherLesson.getStartTime().equals(endTime);
     }
 
     /**
@@ -53,15 +71,9 @@ public class Lesson {
         if (otherLesson.getDay() != day) {
             return false;
         }
-        LocalTime otherStart = otherLesson.getStartTime();
-        LocalTime otherEnd = otherLesson.getEndTime();
-
-        if (otherStart.isAfter(startTime) && otherStart.isBefore(endTime)) {
-            return true;
-        } else if (otherEnd.isAfter(startTime) && otherEnd.isBefore(endTime)) {
-            return true;
-        }
-        return false;
+        // lessons are constructed with valid start-end times
+        // to check NO OVERLAP, ensure otherEnd <= currentStart xor otherStart >= currentEnd
+        return !(isAfter(otherLesson) ^ isBefore(otherLesson));
     }
 
     /**
@@ -71,7 +83,7 @@ public class Lesson {
      *  String of lesson type
      */
     private String getLessonTypeString() {
-        switch(lessonType) {
+        switch (lessonType) {
         case LECTURE:
             return "Lecture";
         case TUTORIAL:
@@ -95,8 +107,8 @@ public class Lesson {
      *  String representation of lesson
      */
     public String toString() {
-        DateTimeFormatter time = DateTimeFormatter.ofPattern("Hm");
-        return String.format("%s %s: %s %s-%s", module.getModuleCode(), getLessonTypeString(),
+        DateTimeFormatter time = DateTimeFormatter.ofPattern("Hmm");
+        return String.format("%s %s: %s %s-%s", moduleCode, getLessonTypeString(),
                 day.toString(), startTime.format(time), endTime.format(time));
     }
 }

--- a/src/main/java/seedu/duke/data/Lesson.java
+++ b/src/main/java/seedu/duke/data/Lesson.java
@@ -1,0 +1,102 @@
+package seedu.duke.data;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public class Lesson {
+    private Module module;
+    private String description;
+    private LessonType lessonType;
+    private DayOfWeek day;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    public Lesson(Module module, LessonType lessonType, DayOfWeek day, LocalTime startTime, LocalTime endTime) {
+        this.module = module;
+        this.lessonType = lessonType;
+        this.day = day;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalTime getEndTime() {
+        return endTime;
+    }
+
+    public DayOfWeek getDay() {
+        return day;
+    }
+
+    /**
+     * Checks for time period overlap with the specified Lesson.
+     *
+     * @param otherLesson
+     *  The specified lesson
+     * @return
+     *  Whether their start and end times overlap
+     */
+    public boolean checkOverlap(Lesson otherLesson) {
+        if (otherLesson.getDay() != day) {
+            return false;
+        }
+        LocalTime otherStart = otherLesson.getStartTime();
+        LocalTime otherEnd = otherLesson.getEndTime();
+
+        if (otherStart.isAfter(startTime) && otherStart.isBefore(endTime)) {
+            return true;
+        } else if (otherEnd.isAfter(startTime) && otherEnd.isBefore(endTime)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Generates string based on lesson type.
+     *
+     * @return
+     *  String of lesson type
+     */
+    private String getLessonTypeString() {
+        switch(lessonType) {
+        case LECTURE:
+            return "Lecture";
+        case TUTORIAL:
+            return "Tutorial";
+        case LAB:
+            return "Lab";
+        case SEMINAR:
+            return "Seminar";
+        case RECITATION:
+            return "Recitation";
+        default:
+            return "Session";
+        }
+    }
+
+    /**
+     * Creates string representation of lesson.
+     * e.g. CS1010 Lecture: Monday 1400-1500
+     *
+     * @return
+     *  String representation of lesson
+     */
+    public String toString() {
+        DateTimeFormatter time = DateTimeFormatter.ofPattern("Hm");
+        return String.format("%s %s: %s %s-%s", module.getModuleCode(), getLessonTypeString(),
+                day.toString(), startTime.format(time), endTime.format(time));
+    }
+}

--- a/src/main/java/seedu/duke/data/Lesson.java
+++ b/src/main/java/seedu/duke/data/Lesson.java
@@ -51,6 +51,10 @@ public class Lesson {
         return day;
     }
 
+    public LessonType getLessonType() {
+        return lessonType;
+    }
+
     public boolean isAfter(Lesson otherLesson) {
         return otherLesson.getEndTime().isBefore(startTime) || otherLesson.getEndTime().equals(startTime);
     }
@@ -101,7 +105,7 @@ public class Lesson {
 
     /**
      * Creates string representation of lesson.
-     * e.g. CS1010 Lecture: Monday 1400-1500
+     * e.g. CS1010 Lecture: MONDAY 1400-1500
      *
      * @return
      *  String representation of lesson

--- a/src/main/java/seedu/duke/data/LessonFilter.java
+++ b/src/main/java/seedu/duke/data/LessonFilter.java
@@ -1,0 +1,5 @@
+package seedu.duke.data;
+
+public interface LessonFilter {
+    boolean filter(Lesson l);
+}

--- a/src/main/java/seedu/duke/data/LessonManager.java
+++ b/src/main/java/seedu/duke/data/LessonManager.java
@@ -25,7 +25,7 @@ public class LessonManager {
      * @param newLesson
      *  The new Lesson object
      */
-    public static void addLesson(Lesson newLesson) throws LessonInvalidTimeException{
+    public static void addLesson(Lesson newLesson) throws LessonInvalidTimeException {
         DayOfWeek lessonDay = newLesson.getDay();
 
         // if lessonMap is not initialised yet...
@@ -90,6 +90,28 @@ public class LessonManager {
 
     public static int getLessonCountOnDay(DayOfWeek day) {
         return lessonMap.get(day).size();
+    }
+
+    /**
+     * Returns an ArrayList with lessons by filtering all lessons in lessonMap through the given LessonFilter.
+     *
+     * @param currentFilter
+     *  The current LessonFilter in use
+     * @return
+     *  The filtered ArrayList of lessons generated from lessonMap
+     */
+    public static ArrayList<Lesson> filterLessons(LessonFilter currentFilter) {
+        ArrayList<Lesson> outputList = new ArrayList<>();
+
+        for (DayOfWeek eachDay : DayOfWeek.values()) {
+            ArrayList<Lesson> currentDay = lessonMap.get(eachDay);
+            for (Lesson eachLesson : currentDay) {
+                if (currentFilter.filter(eachLesson)) {
+                    outputList.add(eachLesson);
+                }
+            }
+        }
+        return outputList;
     }
 
     /**

--- a/src/main/java/seedu/duke/data/LessonManager.java
+++ b/src/main/java/seedu/duke/data/LessonManager.java
@@ -1,0 +1,79 @@
+package seedu.duke.data;
+
+import seedu.duke.exception.LessonNotFoundException;
+
+import java.time.DayOfWeek;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class LessonManager {
+    private static HashMap<DayOfWeek, ArrayList<Lesson>> lessonMap = new HashMap<>();
+
+    /**
+     * Inserts a Lesson object in the correct position in the correct ArrayList in lessonMap, based on its day and time.
+     *
+     * @param newLesson
+     *  The new Lesson object
+     */
+    public void addLesson(Lesson newLesson) {
+        DayOfWeek lessonDay = newLesson.getDay();
+
+        // if there are no lessons on that day yet...
+        if (!lessonMap.containsKey(lessonDay)) {
+            ArrayList<Lesson> newDayLessons = new ArrayList<>();
+            newDayLessons.add(newLesson);
+            lessonMap.put(lessonDay, new ArrayList<>());
+            return;
+        }
+
+        int indexToInsertNewLesson = 0;
+        for (int i = 0; i < lessonMap.get(lessonDay).size(); i++) {
+            Lesson eachLesson = lessonMap.get(lessonDay).get(i);
+            if (newLesson.checkOverlap(eachLesson)) {
+                return;
+            }
+            // insert before the lesson which starts right after newLesson
+            // each day ArrayList in lessonMap is hence always sorted due to addLesson's logic
+            if (eachLesson.getStartTime().isAfter(newLesson.getEndTime())) {
+                indexToInsertNewLesson = i;
+            }
+        }
+        lessonMap.get(lessonDay).add(indexToInsertNewLesson, newLesson);
+    }
+
+    /**
+     * Removes the lesson at lessonIndex on the given day.
+     *
+     * @param day
+     *  The specified day
+     * @param lessonIndex
+     *  The index of the lesson to be removed
+     */
+    public void removeLesson(DayOfWeek day, int lessonIndex) throws LessonNotFoundException{
+        if (!lessonMap.containsKey(day)) {
+            throw new LessonNotFoundException();
+        }
+        if (lessonIndex < 0 || lessonIndex >= lessonMap.get(day).size()) {
+            throw new LessonNotFoundException();
+        }
+        lessonMap.get(day).remove(lessonIndex);
+    }
+
+    /**
+     * Returns the ArrayList of lessons on the given day.
+     *
+     * @param day
+     *  The specified day
+     * @return
+     *  The ArrayList of lessons on that day
+     * @throws LessonNotFoundException
+     *  If there are no lessons on that day
+     */
+    public ArrayList<Lesson> getDayLessonList(DayOfWeek day) throws LessonNotFoundException{
+        if (!lessonMap.containsKey(day)) {
+            throw new LessonNotFoundException();
+        }
+        return lessonMap.get(day);
+    }
+
+}

--- a/src/main/java/seedu/duke/data/LessonType.java
+++ b/src/main/java/seedu/duke/data/LessonType.java
@@ -1,0 +1,10 @@
+package seedu.duke.data;
+
+enum LessonType {
+    TUTORIAL,
+    LECTURE,
+    SEMINAR,
+    LAB,
+    RECITATION,
+    SESSION
+}

--- a/src/main/java/seedu/duke/exception/LessonInvalidTimeException.java
+++ b/src/main/java/seedu/duke/exception/LessonInvalidTimeException.java
@@ -1,0 +1,4 @@
+package seedu.duke.exception;
+
+public class LessonInvalidTimeException extends Exception{
+}

--- a/src/main/java/seedu/duke/exception/LessonNotFoundException.java
+++ b/src/main/java/seedu/duke/exception/LessonNotFoundException.java
@@ -1,0 +1,4 @@
+package seedu.duke.exception;
+
+public class LessonNotFoundException extends Exception{
+}

--- a/src/test/java/seedu/duke/data/LessonTest.java
+++ b/src/test/java/seedu/duke/data/LessonTest.java
@@ -23,7 +23,7 @@ public class LessonTest {
     static final LocalTime time_15 = LocalTime.of(15,0);
 
     @BeforeEach
-    void setupModObjects() throws LessonInvalidTimeException{
+    void setupModObjects() throws LessonInvalidTimeException {
         lesson1 = new Lesson(MOD_CODE_1, LessonType.LECTURE, DayOfWeek.MONDAY, time_12, time_13);
         lesson2 = new Lesson(MOD_CODE_2, LessonType.LECTURE, DayOfWeek.MONDAY, time_14, time_15);
         LessonManager.initialise();
@@ -70,5 +70,29 @@ public class LessonTest {
         assertEquals(1, LessonManager.getLessonCountOnDay(DayOfWeek.MONDAY));
         LessonManager.removeLesson(DayOfWeek.MONDAY, 0);
         assertEquals(0, LessonManager.getLessonCountOnDay(DayOfWeek.MONDAY));
+    }
+
+    @Test
+    void verifyException_lessonConstruction_withInvalidTime() {
+        assertThrows(LessonInvalidTimeException.class,
+            () -> new Lesson(MOD_CODE_1, LessonType.LAB, DayOfWeek.TUESDAY, time_13, time_12));
+        assertThrows(LessonInvalidTimeException.class,
+            () -> new Lesson(MOD_CODE_1, LessonType.LAB, DayOfWeek.TUESDAY, time_12, time_12));
+    }
+
+    @Test
+    void verifyLessonFilter_isWorking() {
+        LessonFilter filterTuesday = (l) -> l.getDay().equals(DayOfWeek.TUESDAY);
+        assertEquals(0, LessonManager.filterLessons(filterTuesday).size());
+
+        LessonFilter filterMonday = (l) -> l.getDay().equals(DayOfWeek.MONDAY);
+        assertEquals(2, LessonManager.filterLessons(filterMonday).size());
+
+        LessonFilter filterMonBefore2 = (l) -> l.getDay().equals(DayOfWeek.MONDAY) && l.getEndTime().isBefore(time_14);
+        assertEquals(1, LessonManager.filterLessons(filterMonBefore2).size());
+
+        String testCode = MOD_CODE_1;
+        LessonFilter filterVariableModCode = (l) -> l.getModuleCode().equalsIgnoreCase(testCode);
+        assertEquals(1, LessonManager.filterLessons(filterVariableModCode).size());
     }
 }

--- a/src/test/java/seedu/duke/data/LessonTest.java
+++ b/src/test/java/seedu/duke/data/LessonTest.java
@@ -1,0 +1,74 @@
+package seedu.duke.data;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.duke.exception.LessonInvalidTimeException;
+import seedu.duke.exception.LessonNotFoundException;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LessonTest {
+    static Lesson lesson1;
+    static Lesson lesson2;
+    static final String MOD_CODE_1 = "CS2113T";
+    static final String MOD_CODE_2 = "CG2271";
+    static final String MOD_CODE_3 = "MA1511";
+    static final LocalTime time_12 = LocalTime.of(12,0);
+    static final LocalTime time_13 = LocalTime.of(13,0);
+    static final LocalTime time_14 = LocalTime.of(14,0);
+    static final LocalTime time_15 = LocalTime.of(15,0);
+
+    @BeforeEach
+    void setupModObjects() throws LessonInvalidTimeException{
+        lesson1 = new Lesson(MOD_CODE_1, LessonType.LECTURE, DayOfWeek.MONDAY, time_12, time_13);
+        lesson2 = new Lesson(MOD_CODE_2, LessonType.LECTURE, DayOfWeek.MONDAY, time_14, time_15);
+        LessonManager.initialise();
+        LessonManager.addLesson(lesson1);
+        LessonManager.addLesson(lesson2);
+    }
+
+    @Test
+    void getOverlapException_addLesson() throws LessonInvalidTimeException, LessonNotFoundException {
+        Lesson testLesson1 = new Lesson(MOD_CODE_3, LessonType.LECTURE, DayOfWeek.MONDAY, time_12, time_13);
+        assertThrows(LessonInvalidTimeException.class, () -> LessonManager.addLesson(testLesson1));
+
+        Lesson testLesson2 = new Lesson(MOD_CODE_3, LessonType.LECTURE, DayOfWeek.MONDAY, time_12, time_14);
+        assertThrows(LessonInvalidTimeException.class, () -> LessonManager.addLesson(testLesson2));
+
+        Lesson testLesson3 = new Lesson(MOD_CODE_3, LessonType.LECTURE, DayOfWeek.MONDAY, time_13, time_15);
+        assertThrows(LessonInvalidTimeException.class, () -> LessonManager.addLesson(testLesson3));
+    }
+
+    @Test
+    void verify_LessonNotFoundException_isThrown() {
+        assertThrows(LessonNotFoundException.class, () -> LessonManager.removeLesson(DayOfWeek.TUESDAY, 0));
+        assertThrows(LessonNotFoundException.class, () -> LessonManager.removeLesson(DayOfWeek.MONDAY, -1));
+        assertThrows(LessonNotFoundException.class, () -> LessonManager.removeLesson(DayOfWeek.MONDAY, 2));
+    }
+
+    @Test
+    void verify_addLesson_sortsLessons() throws LessonNotFoundException, LessonInvalidTimeException {
+        assertEquals(MOD_CODE_1, LessonManager.getDayLessonList(DayOfWeek.MONDAY).get(0).getModuleCode());
+        assertEquals(MOD_CODE_2, LessonManager.getDayLessonList(DayOfWeek.MONDAY).get(1).getModuleCode());
+
+        String testCode = "Test Code";
+        Lesson testLesson = new Lesson(testCode, LessonType.LECTURE, DayOfWeek.MONDAY, time_13, time_14);
+        LessonManager.addLesson(testLesson);
+        assertEquals(MOD_CODE_1, LessonManager.getDayLessonList(DayOfWeek.MONDAY).get(0).getModuleCode());
+        assertEquals(testCode, LessonManager.getDayLessonList(DayOfWeek.MONDAY).get(1).getModuleCode());
+        assertEquals(MOD_CODE_2, LessonManager.getDayLessonList(DayOfWeek.MONDAY).get(2).getModuleCode());
+    }
+
+    @Test
+    void verifyLessonCount_afterDeletingLessons() throws LessonNotFoundException {
+        assertEquals(2, LessonManager.getLessonCountOnDay(DayOfWeek.MONDAY));
+        LessonManager.removeLesson(DayOfWeek.MONDAY, 0);
+        assertEquals(1, LessonManager.getLessonCountOnDay(DayOfWeek.MONDAY));
+        LessonManager.removeLesson(DayOfWeek.MONDAY, 0);
+        assertEquals(0, LessonManager.getLessonCountOnDay(DayOfWeek.MONDAY));
+    }
+}

--- a/src/test/java/seedu/duke/data/ModuleTest.java
+++ b/src/test/java/seedu/duke/data/ModuleTest.java
@@ -18,7 +18,7 @@ public class ModuleTest {
         normalMod1 = new Module(MOD_CODE_1);
         normalMod1.setTitle("Test");
         normalMod2 = new Module(MOD_CODE_2);
-        normalMod1.setTitle("Test 2");
+        normalMod2.setTitle("Test 2");
         try {
             ModuleManager.clearModules();
             ModuleManager.add(normalMod1);


### PR DESCRIPTION
Introduced new Lesson and LessonManager classes, along with some other goodies.

Lesson class:
- Has the following properties:
  - Module code (`String`)
  - Description (optional `String`)
  - Lesson type (an enum)
  - Day of week (a built-in enum)
  - Start time (`LocalTime`)
  - End time (`LocalTime`)
- Has getters but only has setter for description.
  - Will add ability to remove based on filter.
-  Has `checkOverlap(Lesson)`, `isAfter(Lesson)`, `isBefore(Lesson)` to compare start/end times with other Lessons.
- `toString()` returns lesson in this format: CS1010 Lecture: MONDAY 1400-1500

LessonManager:
- Stores lessons in a `HashMap<DayOfWeek, ArrayList<Lesson>>`.
- `addLesson(Lesson)` adds the Lesson object to the correct day in the chronologically correct order (earliest is lowest index).
- `removeLesson(DayOfWeek, int)` removes Lessons based on day and index.
- `getDayLessonList(DayOfWeek)` and `getLessonCountOnDay(DayOfWeek)` do as they are named.
- Most important feature is probably `filterLessons(LessonFilter)`:
  - `LessonFilter` is an interface with only one method, basically allowing you to make lambda functions.
    - e.g. `LessonFilter filterTuesday = (l) -> l.getDay().equals(DayOfWeek.TUESDAY);`
  - Use this to basically filter out anything the user needs from the timetable and get an ArrayList of lessons matching the filter.

e.g.  
```
public static ArrayList<Lesson> findLessonsWithLessonType(LessonType lessonType) {
        LessonFilter filterLab = (l) -> l.getLessonType().equals(LessonType.LAB);
        return LessonManager.filterLessons(filterLab);
}
```

All Lesson times are verified (for validity, overlaps) before being constructed, and before being added to LessonManager.
Relevant tests were added.