### PR TITLE
Major fix of ModuleManager functions and exceptions

### DIFF
--- a/src/main/java/seedu/duke/command/add/AddModuleCommand.java
+++ b/src/main/java/seedu/duke/command/add/AddModuleCommand.java
@@ -23,7 +23,7 @@ public class AddModuleCommand extends AddCommand {
      * @param module Module code to be added.
      */
     public AddModuleCommand(String module) {
-        this.module = module;
+        this.module = module.toUpperCase();
         setPromptType(PromptType.EDIT);
     }
 

--- a/src/main/java/seedu/duke/command/add/AddModuleCommand.java
+++ b/src/main/java/seedu/duke/command/add/AddModuleCommand.java
@@ -2,8 +2,9 @@ package seedu.duke.command.add;
 
 import seedu.duke.command.CommandResult;
 import seedu.duke.command.PromptType;
-import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
+import seedu.duke.exception.DuplicateModuleException;
+import seedu.duke.exception.ModuleNotProvidedException;
 
 import static seedu.duke.util.ExceptionMessage.MESSAGE_DUPLICATE_MODULE;
 import static seedu.duke.util.ExceptionMessage.MESSAGE_MODULE_NOT_PROVIDED;
@@ -30,12 +31,10 @@ public class AddModuleCommand extends AddCommand {
      * Add the Module to the module list.
      *
      * @param module Module code to be added.
-     * @throws ModuleManager.DuplicateModuleException if the module is already in the list
+     * @throws DuplicateModuleException if the module is already in the list
      */
-    private void addModule(String module) throws ModuleManager.DuplicateModuleException,
-            ModuleManager.ModuleNotFoundException {
-        Module newModule = new Module(module);
-        ModuleManager.add(newModule);
+    private void addModule(String module) throws DuplicateModuleException, ModuleNotProvidedException {
+        ModuleManager.add(module);
     }
 
     /**
@@ -49,9 +48,9 @@ public class AddModuleCommand extends AddCommand {
         try {
             addModule(module);
             message = MESSAGE_ADD_MODULE_SUCCESS;
-        } catch (ModuleManager.DuplicateModuleException e) {
+        } catch (DuplicateModuleException e) {
             message = MESSAGE_DUPLICATE_MODULE;
-        } catch (ModuleManager.ModuleNotFoundException e) {
+        } catch (ModuleNotProvidedException e) {
             message = MESSAGE_MODULE_NOT_PROVIDED;
         }
         return new CommandResult(message);

--- a/src/main/java/seedu/duke/command/delete/DeleteModuleCommand.java
+++ b/src/main/java/seedu/duke/command/delete/DeleteModuleCommand.java
@@ -3,6 +3,7 @@ package seedu.duke.command.delete;
 import seedu.duke.command.CommandResult;
 import seedu.duke.command.PromptType;
 import seedu.duke.data.ModuleManager;
+import seedu.duke.exception.ModuleNotFoundException;
 
 import static seedu.duke.util.ExceptionMessage.MESSAGE_MODULE_NOT_FOUND;
 import static seedu.duke.util.Message.MESSAGE_DELETE_MODULE_SUCCESS;
@@ -28,9 +29,9 @@ public class DeleteModuleCommand extends DeleteCommand {
      * Deletes the module from the module list.
      *
      * @param moduleCode Module code to be deleted.
-     * @throws ModuleManager.ModuleNotFoundException If the module is not found in the module list.
+     * @throws ModuleNotFoundException If the module is not found in the module list.
      */
-    private void deleteModule(String moduleCode) throws ModuleManager.ModuleNotFoundException {
+    private void deleteModule(String moduleCode) throws ModuleNotFoundException {
         ModuleManager.delete(moduleCode);
     }
 
@@ -45,7 +46,7 @@ public class DeleteModuleCommand extends DeleteCommand {
         try {
             deleteModule(moduleCode);
             message = MESSAGE_DELETE_MODULE_SUCCESS;
-        } catch (ModuleManager.ModuleNotFoundException e) {
+        } catch (ModuleNotFoundException e) {
             message = MESSAGE_MODULE_NOT_FOUND;
         }
         return new CommandResult(message);

--- a/src/main/java/seedu/duke/command/delete/DeleteModuleCommand.java
+++ b/src/main/java/seedu/duke/command/delete/DeleteModuleCommand.java
@@ -21,7 +21,7 @@ public class DeleteModuleCommand extends DeleteCommand {
      * @param moduleCode Module code to be deleted.
      */
     public DeleteModuleCommand(String moduleCode) {
-        this.moduleCode = moduleCode;
+        this.moduleCode = moduleCode.toUpperCase();
         setPromptType(PromptType.EDIT);
     }
 

--- a/src/main/java/seedu/duke/command/edit/EditModuleCommand.java
+++ b/src/main/java/seedu/duke/command/edit/EditModuleCommand.java
@@ -4,6 +4,8 @@ import seedu.duke.command.CommandResult;
 import seedu.duke.command.PromptType;
 import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
+import seedu.duke.exception.DuplicateModuleException;
+import seedu.duke.exception.ModuleNotFoundException;
 import seedu.duke.exception.ModuleNotProvidedException;
 
 import java.util.regex.Pattern;
@@ -40,22 +42,6 @@ public class EditModuleCommand extends EditCommand {
     }
 
     /**
-     * Edits the module.
-     *
-     * @param toEdit
-     *  The module to edit
-     * @throws ModuleManager.DuplicateModuleException
-     *  If the new module code is duplicated
-     * @throws ModuleNotProvidedException
-     *  If the new module code is not a recognised NUS module
-     */
-
-    protected void edit(Module toEdit) throws ModuleManager.DuplicateModuleException, ModuleNotProvidedException {
-        toEdit.setModuleCode(newModuleCode);
-        ModuleManager.edit(toEdit, oldModuleCode);
-    }
-
-    /**
      * Executes the <b>Edit Module Command</b> to edit a <b>Module</b> with the <code>module code</code>
      * from the <b>Module List</b>.
      *
@@ -67,15 +53,14 @@ public class EditModuleCommand extends EditCommand {
     @Override
     public CommandResult execute() {
         try {
-            Module toEdit = ModuleManager.getModule(oldModuleCode);
-            edit(toEdit);
+            ModuleManager.edit(newModuleCode, oldModuleCode);
             return new CommandResult(MESSAGE_EDIT_MODULE_SUCCESS);
-        }  catch (ModuleNotProvidedException e) {
+        } catch (ModuleNotProvidedException e) {
             return new CommandResult(MESSAGE_MODULE_NOT_PROVIDED);
-        } catch (ModuleManager.ModuleNotFoundException e) {
-            return new CommandResult(MESSAGE_MODULE_NOT_FOUND);
-        } catch (ModuleManager.DuplicateModuleException e) {
+        } catch (DuplicateModuleException e) {
             return new CommandResult(MESSAGE_DUPLICATE_MODULE);
+        } catch (ModuleNotFoundException e) {
+            return new CommandResult(MESSAGE_MODULE_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/seedu/duke/command/edit/EditModuleCommand.java
+++ b/src/main/java/seedu/duke/command/edit/EditModuleCommand.java
@@ -36,7 +36,7 @@ public class EditModuleCommand extends EditCommand {
      *  The new module code for the module if any
      */
     public EditModuleCommand(String oldModuleCode, String newModuleCode) {
-        this.oldModuleCode = oldModuleCode;
+        this.oldModuleCode = oldModuleCode.toUpperCase();
         this.newModuleCode = newModuleCode.toUpperCase();
         setPromptType(PromptType.EDIT);
     }

--- a/src/main/java/seedu/duke/command/grade/GradeCommand.java
+++ b/src/main/java/seedu/duke/command/grade/GradeCommand.java
@@ -34,7 +34,7 @@ public class GradeCommand extends Command {
      * Grade attained by user for the specific module.
      */
     public GradeCommand(String moduleGraded, double moduleCredit, String grade) {
-        this.moduleGraded = moduleGraded;
+        this.moduleGraded = moduleGraded.toUpperCase();
         this.moduleCredit = moduleCredit;
         this.grade = grade;
         setPromptType(PromptType.EDIT);

--- a/src/main/java/seedu/duke/command/grade/GradeCommand.java
+++ b/src/main/java/seedu/duke/command/grade/GradeCommand.java
@@ -6,6 +6,7 @@ import seedu.duke.command.PromptType;
 import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
 import seedu.duke.exception.InvalidGradeException;
+import seedu.duke.exception.ModuleNotFoundException;
 import seedu.duke.ui.TextUi;
 
 import static seedu.duke.util.ExceptionMessage.MESSAGE_MODULE_NOT_FOUND;
@@ -59,14 +60,12 @@ public class GradeCommand extends Command {
     /**
      * Grades and allocates the Module Credit to the Module.
      *
-     * @param moduleToBeGraded
-     * The module to be graded by user.
      * @throws InvalidGradeException
      * If the grade isn't recognised by the NUS grading schematic
      */
-    private void grade(Module moduleToBeGraded) throws InvalidGradeException, ModuleManager.ModuleNotFoundException {
+    private void grade() throws InvalidGradeException, ModuleNotFoundException {
         if (testGrade(grade)) {
-            ModuleManager.grade(moduleToBeGraded,grade,moduleCredit);
+            ModuleManager.grade(moduleGraded,grade,moduleCredit);
         } else {
             throw new InvalidGradeException();
         }
@@ -81,12 +80,11 @@ public class GradeCommand extends Command {
     @Override
     public CommandResult execute() {
         try {
-            Module moduleToBeGraded = ModuleManager.getModule(moduleGraded);
-            grade(moduleToBeGraded);
+            grade();
             return new CommandResult(MESSAGE_GRADE_MODULE_SUCCESS);
         } catch (InvalidGradeException e) {
             return new CommandResult(MESSAGE_INVALID_GRADE);
-        } catch (ModuleManager.ModuleNotFoundException e) {
+        } catch (ModuleNotFoundException e) {
             return new CommandResult(MESSAGE_MODULE_NOT_FOUND);
         }
     }

--- a/src/main/java/seedu/duke/command/timetable/TimeTableAddCommand.java
+++ b/src/main/java/seedu/duke/command/timetable/TimeTableAddCommand.java
@@ -3,9 +3,9 @@ package seedu.duke.command.timetable;
 import seedu.duke.command.CommandResult;
 import seedu.duke.command.PromptType;
 import seedu.duke.data.Lesson;
-import seedu.duke.data.ModuleManager;
 import seedu.duke.data.TimeTableManager;
 import seedu.duke.exception.LessonInvalidTimeException;
+import seedu.duke.exception.ModuleNotFoundException;
 import seedu.duke.exception.RepeatFrequencyInvalidException;
 
 import static seedu.duke.util.ExceptionMessage.MESSAGE_LESSON_INVALID_TIME;
@@ -30,11 +30,11 @@ public class TimeTableAddCommand extends TimeTableCommand {
      *  When the lesson overlaps with an existing lesson.
      * @throws RepeatFrequencyInvalidException
      *  When the repeat parameter given by the user is not from 0 - 3.
-     * @throws ModuleManager.ModuleNotFoundException
+     * @throws ModuleNotFoundException
      *  When the module to be added to the timetable is not in the module list.
      */
     public void addLessonToTimeTable() throws LessonInvalidTimeException, RepeatFrequencyInvalidException,
-            ModuleManager.ModuleNotFoundException {
+            ModuleNotFoundException {
         if (repeatFreq < 0 || repeatFreq > 3) {
             throw new RepeatFrequencyInvalidException();
         }
@@ -51,7 +51,7 @@ public class TimeTableAddCommand extends TimeTableCommand {
             message = MESSAGE_LESSON_INVALID_TIME;
         } catch (RepeatFrequencyInvalidException e) {
             message = MESSAGE_REPEAT_FREQUENCY_UNKNOWN;
-        } catch (ModuleManager.ModuleNotFoundException e) {
+        } catch (ModuleNotFoundException e) {
             message = MESSAGE_MODULE_NOT_FOUND;
         }
         return new CommandResult(message);

--- a/src/main/java/seedu/duke/data/ModuleManager.java
+++ b/src/main/java/seedu/duke/data/ModuleManager.java
@@ -55,12 +55,12 @@ public class ModuleManager {
     public static void edit(String newModuleCode, String oldModuleCode)
             throws ModuleNotProvidedException, DuplicateModuleException, ModuleNotFoundException {
         logger.getLogger().info("Editing module at old module code: " + oldModuleCode);
-        if (!modulesMap.containsKey(oldModuleCode)) {
+        if (!doesContainMod(oldModuleCode)) {
             logger.getLogger().warning("Old module code not found!");
             throw new ModuleNotFoundException();
         }
         add(newModuleCode);
-        modulesMap.remove(oldModuleCode);
+        delete(oldModuleCode);
     }
 
     /**
@@ -76,7 +76,7 @@ public class ModuleManager {
      * If there is no such module in the user's module list
      */
     public static void grade(String moduleCode, String grade, double moduleCredit) throws ModuleNotFoundException {
-        if (contains(moduleCode)) {
+        if (doesContainMod(moduleCode)) {
             getModule(moduleCode).setModuleGrade(grade);
             getModule(moduleCode).setModuleCredit(moduleCredit);
         } else {
@@ -91,7 +91,7 @@ public class ModuleManager {
      * @return
      *  <code>TRUE</code> if there exists a duplicate, and <code>FALSE</code> otherwise
      */
-    public static boolean contains(String moduleCode) {
+    public static boolean doesContainMod(String moduleCode) {
         for (String eachCode : modulesMap.keySet()) {
             if (eachCode.equalsIgnoreCase(moduleCode)) {
                 return true;
@@ -107,7 +107,7 @@ public class ModuleManager {
      */
     public static void add(String moduleCode) throws DuplicateModuleException, ModuleNotProvidedException {
         logger.getLogger().info("Adding module with code: " + moduleCode);
-        if (contains(moduleCode)) {
+        if (doesContainMod(moduleCode)) {
             logger.getLogger().warning("Can't add module because it already exists!");
             throw new DuplicateModuleException();
         }
@@ -122,7 +122,7 @@ public class ModuleManager {
      */
     public static void delete(String moduleCode) throws ModuleNotFoundException {
         logger.getLogger().info("Deleting module with code: " + moduleCode);
-        if (!contains(moduleCode)) {
+        if (!doesContainMod(moduleCode)) {
             logger.getLogger().warning("Can't delete module because it doesn't exist!");
             throw new ModuleNotFoundException();
         }

--- a/src/main/java/seedu/duke/data/ModuleManager.java
+++ b/src/main/java/seedu/duke/data/ModuleManager.java
@@ -1,7 +1,7 @@
 package seedu.duke.data;
 
-import seedu.duke.exception.DataNotFoundException;
-import seedu.duke.exception.DuplicateDataException;
+import seedu.duke.exception.DuplicateModuleException;
+import seedu.duke.exception.ModuleNotFoundException;
 import seedu.duke.exception.ModuleNotProvidedException;
 import seedu.duke.ui.TextUi;
 import seedu.duke.DukeLogger;
@@ -41,49 +41,44 @@ public class ModuleManager {
     /**
      * Edits a module in the Module List by replacing the old module object with a new one.
      *
-     * @param newModule
-     *  The new module that replaces the old one.
+     * @param newModuleCode
+     *  The new module code of the new module that replaces the old one.
      * @param oldModuleCode
      *  The module code of the module to be edited.
      * @throws ModuleNotProvidedException
      *  If there is no module with the new module code offered by NUS
      * @throws DuplicateModuleException
      *  If there are duplicate modules with the same module code as the new module code in the Module List
+     * @throws ModuleNotFoundException
+     *  If the old module is not found
      */
-    public static void edit(Module newModule, String oldModuleCode)
-            throws ModuleNotProvidedException, DuplicateModuleException {
+    public static void edit(String newModuleCode, String oldModuleCode)
+            throws ModuleNotProvidedException, DuplicateModuleException, ModuleNotFoundException {
         logger.getLogger().info("Editing module at old module code: " + oldModuleCode);
-        //modulesMap.get(module.getCode()).setTitle(moduleDescription);
-        Module oldModule = modulesMap.get(oldModuleCode);
         if (!modulesMap.containsKey(oldModuleCode)) {
             logger.getLogger().warning("Old module code not found!");
-            throw new ModuleNotProvidedException();
+            throw new ModuleNotFoundException();
         }
-        if (oldModule.isSameModule(newModule)) {
-            logger.getLogger().warning("Can't edit to new mod code because it exists!");
-            throw new DuplicateModuleException();
-        }
+        add(newModuleCode);
         modulesMap.remove(oldModuleCode);
-        modulesMap.put(newModule.getModuleCode(), newModule);
     }
 
     /**
      * Checks if the module to be graded is in the moduleMap and assigns the grade to the module.
      *
-     * @param module
-     * module to be graded
+     * @param moduleCode
+     * Module code of the module to be graded
      * @param grade
-     * the grade to be assigned
+     * The grade to be assigned
      * @param moduleCredit
-     * the modules assigned module credit 
+     * The module's assigned module credit
      * @throws ModuleNotFoundException
-     * if there is no such module in the module list input by the user
+     * If there is no such module in the user's module list
      */
-    public static void grade(Module module, String grade, double moduleCredit) throws ModuleNotFoundException {
-        String moduleCode = module.getModuleCode();
+    public static void grade(String moduleCode, String grade, double moduleCredit) throws ModuleNotFoundException {
         if (contains(moduleCode)) {
-            modulesMap.get(moduleCode).setModuleGrade(grade);
-            modulesMap.get(moduleCode).setModuleCredit(moduleCredit);
+            getModule(moduleCode).setModuleGrade(grade);
+            getModule(moduleCode).setModuleCredit(moduleCredit);
         } else {
             throw new ModuleNotFoundException();
         }
@@ -106,19 +101,18 @@ public class ModuleManager {
     }
 
     /**
-     * Adds a module to the Module List.
-     * @param newModule
-     *  The module object to add to the module list
+     * Adds a module to the Module List. Uses the module code to grab the module object from the NUSMods list.
+     * @param moduleCode
+     *  The module code string of the module to add to the module list
      */
-    public static void add(Module newModule) throws DuplicateModuleException, ModuleNotFoundException {
-        logger.getLogger().info("Adding module with code: " + newModule.getModuleCode());
-        if (contains(newModule.getModuleCode())) {
+    public static void add(String moduleCode) throws DuplicateModuleException, ModuleNotProvidedException {
+        logger.getLogger().info("Adding module with code: " + moduleCode);
+        if (contains(moduleCode)) {
             logger.getLogger().warning("Can't add module because it already exists!");
             throw new DuplicateModuleException();
         }
-        Module verifiedNusMod = getNusModule(newModule.getModuleCode());
-        newModule.setTitle(verifiedNusMod.getTitle());
-        modulesMap.put(newModule.getModuleCode(), newModule);
+        Module verifiedNusMod = getNusModule(moduleCode);
+        modulesMap.put(moduleCode, verifiedNusMod);
     }
 
     /**
@@ -145,13 +139,13 @@ public class ModuleManager {
      * @throws ModuleNotFoundException
      *  If the module is not found in the Module List
      */
-    public static Module getNusModule(String moduleCode) throws ModuleNotFoundException {
+    public static Module getNusModule(String moduleCode) throws ModuleNotProvidedException {
         for (Module module : nusModsMap.values()) {
             if (module.getModuleCode().equalsIgnoreCase(moduleCode)) {
                 return module;
             }
         }
-        throw new ModuleNotFoundException();
+        throw new ModuleNotProvidedException();
     }
 
     public static String[] getModCodeList() {
@@ -210,9 +204,4 @@ public class ModuleManager {
         return modulesMap;
     }
 
-    public static class ModuleNotFoundException extends DataNotFoundException {
-    }
-
-    public static class DuplicateModuleException extends DuplicateDataException {
-    }
 }

--- a/src/main/java/seedu/duke/data/TimeTableManager.java
+++ b/src/main/java/seedu/duke/data/TimeTableManager.java
@@ -2,7 +2,7 @@ package seedu.duke.data;
 
 import seedu.duke.exception.LessonInvalidTimeException;
 import seedu.duke.exception.TimeTableInitialiseException;
-import seedu.duke.data.ModuleManager.ModuleNotFoundException;
+import seedu.duke.exception.ModuleNotFoundException;
 import seedu.duke.DukeLogger;
 
 import java.time.DayOfWeek;

--- a/src/main/java/seedu/duke/data/TimeTableManager.java
+++ b/src/main/java/seedu/duke/data/TimeTableManager.java
@@ -79,7 +79,7 @@ public class TimeTableManager {
      */
     public static void addLesson(Lesson lesson, int repeat) throws LessonInvalidTimeException, ModuleNotFoundException {
         logger.getLogger().info("Adding lesson: " + lesson.toString() + " with repeat: " + repeat);
-        if (!ModuleManager.contains(lesson.getModuleCode())) {
+        if (!ModuleManager.doesContainMod(lesson.getModuleCode())) {
             logger.getLogger().warning("Could not add lesson as module not in user module list!");
             throw new ModuleNotFoundException();
         }

--- a/src/main/java/seedu/duke/data/storage/Encoder.java
+++ b/src/main/java/seedu/duke/data/storage/Encoder.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 
 import com.alibaba.fastjson.JSON;
 import seedu.duke.data.TimeTableManager;
+import seedu.duke.exception.ModuleNotFoundException;
+import seedu.duke.exception.ModuleNotProvidedException;
 
 /**
  * Manages all inputs to files, and the conversion from Object in memory to String in file.
@@ -61,10 +63,10 @@ public class Encoder {
      *  The name of the file to save to
      * @throws IOException
      *  When there is an error preparing the save file
-     * @throws ModuleManager.ModuleNotFoundException
+     * @throws ModuleNotFoundException
      *  If module not found (should never happen)
      */
-    public static void saveModules(String dataFileName) throws IOException, ModuleManager.ModuleNotFoundException {
+    public static void saveModules(String dataFileName) throws IOException, ModuleNotFoundException {
         File mySaveFile = new File(dataFileName);
         prepareSaveFile(mySaveFile);
 
@@ -82,10 +84,10 @@ public class Encoder {
      *  The name of the file to save to
      * @throws IOException
      *  When there is an error preparing the save file
-     * @throws ModuleManager.ModuleNotFoundException
+     * @throws ModuleNotFoundException
      *  If module not found (should never happen)
      */
-    public static void saveNusModules(String dataFileName) throws IOException, ModuleManager.ModuleNotFoundException {
+    public static void saveNusModules(String dataFileName) throws IOException, ModuleNotProvidedException {
         File mySaveFile = new File(dataFileName);
         prepareSaveFile(mySaveFile);
         Module currentModule;

--- a/src/main/java/seedu/duke/data/storage/InputOutputManager.java
+++ b/src/main/java/seedu/duke/data/storage/InputOutputManager.java
@@ -3,6 +3,8 @@ package seedu.duke.data.storage;
 import com.alibaba.fastjson.JSONException;
 import seedu.duke.data.ModuleManager;
 import seedu.duke.data.TimeTableManager;
+import seedu.duke.exception.ModuleNotFoundException;
+import seedu.duke.exception.ModuleNotProvidedException;
 import seedu.duke.util.FileName;
 import seedu.duke.data.TaskManager;
 import seedu.duke.DukeLogger;
@@ -155,7 +157,7 @@ public class InputOutputManager {
                 Encoder.saveTasks(USER_TASK_FILE.toString());
             }
             Encoder.saveTimetable(TIMETABLE_FILE.toString()); // always save, even if there's no lessons
-        } catch (ModuleManager.ModuleNotFoundException | TaskManager.TaskNotFoundException | IOException e) {
+        } catch (ModuleNotFoundException | TaskManager.TaskNotFoundException | IOException e) {
             logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
         }
 
@@ -168,7 +170,7 @@ public class InputOutputManager {
         logger.getLogger().info("Saving NUS modules into " + NUS_MOD_F_NAME);
         try {
             Encoder.saveNusModules(NUS_MODULE_FILE.toString());
-        } catch (ModuleManager.ModuleNotFoundException | IOException e) {
+        } catch (ModuleNotFoundException | IOException e) {
             logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
         }
     }

--- a/src/main/java/seedu/duke/data/storage/InputOutputManager.java
+++ b/src/main/java/seedu/duke/data/storage/InputOutputManager.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 
 import java.util.logging.Level;
 
+
 /**
  * Manages all inputs and outputs (to and from files).
  * Encoder and Decoder are only used by InputOutputManager.
@@ -170,7 +171,7 @@ public class InputOutputManager {
         logger.getLogger().info("Saving NUS modules into " + NUS_MOD_F_NAME);
         try {
             Encoder.saveNusModules(NUS_MODULE_FILE.toString());
-        } catch (ModuleNotFoundException | IOException e) {
+        } catch (ModuleNotProvidedException | IOException e) {
             logger.getLogger().log(Level.WARNING, e.getLocalizedMessage(), e);
         }
     }

--- a/src/main/java/seedu/duke/exception/DuplicateModuleException.java
+++ b/src/main/java/seedu/duke/exception/DuplicateModuleException.java
@@ -1,0 +1,4 @@
+package seedu.duke.exception;
+
+public class DuplicateModuleException extends DuplicateDataException {
+}

--- a/src/main/java/seedu/duke/exception/ModuleNotFoundException.java
+++ b/src/main/java/seedu/duke/exception/ModuleNotFoundException.java
@@ -1,0 +1,4 @@
+package seedu.duke.exception;
+
+public class ModuleNotFoundException extends DataNotFoundException {
+}

--- a/src/main/java/seedu/duke/parser/LessonParser.java
+++ b/src/main/java/seedu/duke/parser/LessonParser.java
@@ -41,7 +41,7 @@ public class LessonParser {
         String endTimeString = lessonMatcher.group(END_TIME_GROUP).trim();
         String lessonTypeString = lessonMatcher.group(LESSON_TYPE_GROUP).toUpperCase().trim();
         // Check if modString is in module list
-        if (!ModuleManager.contains(modString)) {
+        if (!ModuleManager.doesContainMod(modString)) {
             throw new ModuleNotFoundException();
         }
         // Convert dayString to DayOfWeek
@@ -71,7 +71,7 @@ public class LessonParser {
 
         if (!modString.equals(SKIP_PARAMETER_CHAR)) {
             // Check if modString is in module list
-            if (!ModuleManager.contains(modString)) {
+            if (!ModuleManager.doesContainMod(modString)) {
                 throw new ModuleNotFoundException();
             } else {
                 LessonFilter modFilter = (l) -> l.getModuleCode().equals(modString);

--- a/src/main/java/seedu/duke/parser/LessonParser.java
+++ b/src/main/java/seedu/duke/parser/LessonParser.java
@@ -5,6 +5,7 @@ import seedu.duke.data.LessonFilter;
 import seedu.duke.data.LessonType;
 import seedu.duke.data.ModuleManager;
 import seedu.duke.exception.LessonInvalidTimeException;
+import seedu.duke.exception.ModuleNotFoundException;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
@@ -27,12 +28,12 @@ public class LessonParser {
      *
      * @param lessonMatcher Matcher for the parameters.
      * @return Lesson created from the Lesson parameters.
-     * @throws ModuleManager.ModuleNotFoundException When the module is not found in the module list.
+     * @throws ModuleNotFoundException When the module is not found in the module list.
      * @throws LessonInvalidTimeException When the start is greater than or equal to end time of the Lesson.
      * @throws DateTimeParseException When the time of either the start or end is in the wrong format.
      */
     public static Lesson parseLesson(Matcher lessonMatcher) throws
-            ModuleManager.ModuleNotFoundException, LessonInvalidTimeException, DateTimeParseException,
+            ModuleNotFoundException, LessonInvalidTimeException, DateTimeParseException,
             IllegalArgumentException {
         String modString = lessonMatcher.group(MODULE_GROUP).toUpperCase().trim();
         String dayString = lessonMatcher.group(DAY_GROUP).toUpperCase().trim();
@@ -41,7 +42,7 @@ public class LessonParser {
         String lessonTypeString = lessonMatcher.group(LESSON_TYPE_GROUP).toUpperCase().trim();
         // Check if modString is in module list
         if (!ModuleManager.contains(modString)) {
-            throw new ModuleManager.ModuleNotFoundException();
+            throw new ModuleNotFoundException();
         }
         // Convert dayString to DayOfWeek
         DayOfWeek dayOfWeek = DayOfWeek.valueOf(dayString);
@@ -58,7 +59,7 @@ public class LessonParser {
 
 
     public static ArrayList<LessonFilter> parseFilterLesson(Matcher filterMatcher) throws
-            ModuleManager.ModuleNotFoundException, DateTimeParseException,
+            ModuleNotFoundException, DateTimeParseException,
             IllegalArgumentException {
         final String modString = filterMatcher.group(MODULE_GROUP).toUpperCase().trim();
         final String dayString = filterMatcher.group(DAY_GROUP).toUpperCase().trim();
@@ -71,7 +72,7 @@ public class LessonParser {
         if (!modString.equals(SKIP_PARAMETER_CHAR)) {
             // Check if modString is in module list
             if (!ModuleManager.contains(modString)) {
-                throw new ModuleManager.ModuleNotFoundException();
+                throw new ModuleNotFoundException();
             } else {
                 LessonFilter modFilter = (l) -> l.getModuleCode().equals(modString);
                 filterList.add(modFilter);

--- a/src/main/java/seedu/duke/parser/TimeTableCommandParser.java
+++ b/src/main/java/seedu/duke/parser/TimeTableCommandParser.java
@@ -9,9 +9,9 @@ import seedu.duke.command.timetable.TimeTableFilterCommand;
 import seedu.duke.command.timetable.TimeTableViewCommand;
 import seedu.duke.data.Lesson;
 import seedu.duke.data.LessonFilter;
-import seedu.duke.data.ModuleManager;
 import seedu.duke.exception.InvalidMatchException;
 import seedu.duke.exception.LessonInvalidTimeException;
+import seedu.duke.exception.ModuleNotFoundException;
 
 import java.time.DayOfWeek;
 import java.time.format.DateTimeParseException;
@@ -85,7 +85,7 @@ public abstract class TimeTableCommandParser {
                 command = parseTimeTableViewCommand(commandFlag, timeTableParams);
                 break;
             }
-        } catch (ModuleManager.ModuleNotFoundException e) {
+        } catch (ModuleNotFoundException e) {
             return new IncorrectCommand(MESSAGE_MODULE_NOT_FOUND);
         } catch (LessonInvalidTimeException e) {
             return new IncorrectCommand(MESSAGE_LESSON_INVALID_TIME);
@@ -130,13 +130,13 @@ public abstract class TimeTableCommandParser {
      * e.g. timetable -add CS2101 FRIDAY 1400 1600 LECTURE 1
      *
      * @return TimeTableAddCommand or IncorrectCommand
-     * @throws ModuleManager.ModuleNotFoundException When the module is not found in the module list.
+     * @throws ModuleNotFoundException When the module is not found in the module list.
      * @throws LessonInvalidTimeException When the start is greater than or equal to end time of the Lesson.
      * @throws DateTimeParseException When the time of either the start or end is in the wrong format.
      * @throws InvalidMatchException When the lessonParams do not match the TimeTableAddCommand regex.
      */
     private static Command parseTimeTableAddCommand(String lessonParams)
-            throws ModuleManager.ModuleNotFoundException, LessonInvalidTimeException,
+            throws ModuleNotFoundException, LessonInvalidTimeException,
             DateTimeParseException, InvalidMatchException {
         Matcher lessonMatcher = TIMETABLE_LESSON_PARAMETER_FORMAT.matcher(lessonParams);
 
@@ -171,7 +171,7 @@ public abstract class TimeTableCommandParser {
     }
 
     public static Command parseTimeTableFilterCommand(String filterParams) throws
-            InvalidMatchException, ModuleManager.ModuleNotFoundException {
+            InvalidMatchException, ModuleNotFoundException {
         Matcher filterMatcher = TIMETABLE_LESSON_FILTER_PARAMETER_FORMAT.matcher(filterParams);
         Parser.matcherMatches(filterMatcher, filterParams, TIMETABLE_LESSON_FILTER_USER_FORMAT,
                 TimeTableCommand.PROMPT_HELP);

--- a/src/test/java/seedu/duke/command/edit/EditModuleCommandTest.java
+++ b/src/test/java/seedu/duke/command/edit/EditModuleCommandTest.java
@@ -4,17 +4,16 @@ import org.junit.jupiter.api.Test;
 import seedu.duke.Executor;
 import seedu.duke.command.CommandResult;
 import seedu.duke.data.Module;
-import seedu.duke.data.ModuleManager;
 import seedu.duke.data.storage.Decoder;
+import seedu.duke.exception.DuplicateModuleException;
 
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.duke.util.Message.MESSAGE_EDIT_TASK_SUCCESS;
 
 class EditModuleCommandTest {
     @Test
-    void execute() throws ModuleManager.DuplicateModuleException {
+    void execute() throws DuplicateModuleException {
         HashMap<String, Module> modulesMap = Decoder.loadModules("data/" + "moduleList.json");
         //ModuleManager.add(new Module("CS1231", "AAA"));
 

--- a/src/test/java/seedu/duke/command/timetable/TimeTableCommandTest.java
+++ b/src/test/java/seedu/duke/command/timetable/TimeTableCommandTest.java
@@ -8,11 +8,12 @@ import seedu.duke.command.CommandResult;
 import seedu.duke.command.IncorrectCommand;
 import seedu.duke.data.Lesson;
 import seedu.duke.data.LessonType;
-import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
 import seedu.duke.data.TimeTableManager;
+import seedu.duke.exception.DuplicateModuleException;
 import seedu.duke.exception.InvalidMatchException;
 import seedu.duke.exception.LessonInvalidTimeException;
+import seedu.duke.exception.ModuleNotProvidedException;
 import seedu.duke.exception.TimeTableInitialiseException;
 import seedu.duke.parser.TimeTableCommandParser;
 import seedu.duke.util.ExceptionMessage;
@@ -45,11 +46,11 @@ public class TimeTableCommandTest {
     static final LessonType LESSON_TYPE = LessonType.LECTURE;
 
     @BeforeAll
-    static void setupUserMods() throws ModuleManager.DuplicateModuleException, ModuleManager.ModuleNotFoundException {
+    static void setupUserMods() throws DuplicateModuleException, ModuleNotProvidedException {
         ModuleManager.clearModules();
-        ModuleManager.add(new Module(MOD_CODE_1));
-        ModuleManager.add(new Module(MOD_CODE_2));
-        ModuleManager.add(new Module(MOD_CODE_3));
+        ModuleManager.add(MOD_CODE_1);
+        ModuleManager.add(MOD_CODE_2);
+        ModuleManager.add(MOD_CODE_3);
     }
 
     @BeforeEach

--- a/src/test/java/seedu/duke/data/ModuleTest.java
+++ b/src/test/java/seedu/duke/data/ModuleTest.java
@@ -2,26 +2,22 @@ package seedu.duke.data;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import seedu.duke.exception.DuplicateModuleException;
+import seedu.duke.exception.ModuleNotFoundException;
 import seedu.duke.exception.ModuleNotProvidedException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ModuleTest {
-    static Module normalMod1;
-    static Module normalMod2;
     static final String MOD_CODE_1 = "CS2113T";
     static final String MOD_CODE_2 = "CG2271";
 
     @BeforeEach
-    void setupModObjects() throws ModuleManager.DuplicateModuleException, ModuleManager.ModuleNotFoundException {
-        normalMod1 = new Module(MOD_CODE_1);
-        normalMod1.setTitle("Test");
-        normalMod2 = new Module(MOD_CODE_2);
-        normalMod2.setTitle("Test 2");
+    void setupModObjects() throws DuplicateModuleException, ModuleNotProvidedException {
         ModuleManager.clearModules();
-        ModuleManager.add(normalMod1);
-        ModuleManager.add(normalMod2);
+        ModuleManager.add(MOD_CODE_1);
+        ModuleManager.add(MOD_CODE_2);
     }
     
     @Test
@@ -30,38 +26,33 @@ public class ModuleTest {
     }
 
     @Test
-    void getModule_isCorrect() throws ModuleManager.ModuleNotFoundException {
-        assertEquals(normalMod1.getTitle(), ModuleManager.getModule(MOD_CODE_1).getTitle());
-        assertEquals(normalMod1.getModuleCode(), ModuleManager.getModule(MOD_CODE_1).getModuleCode());
-        assertEquals(normalMod2.getTitle(), ModuleManager.getModule(MOD_CODE_2).getTitle());
-        assertEquals(normalMod2.getModuleCode(), ModuleManager.getModule(MOD_CODE_2).getModuleCode());
+    void getModule_isCorrect() throws ModuleNotFoundException {
+        assertEquals(MOD_CODE_1, ModuleManager.getModule(MOD_CODE_1).getModuleCode());
+        assertEquals(MOD_CODE_2, ModuleManager.getModule(MOD_CODE_2).getModuleCode());
     }
 
     @Test
     void check_moduleNotFoundException_isThrown() {
-        assertThrows(ModuleManager.ModuleNotFoundException.class,
+        assertThrows(ModuleNotFoundException.class,
             () -> ModuleManager.getModule("WHAT1010"));
     }
 
     @Test
-    void editMod_getTitle_equalsNewTitle()
-            throws ModuleManager.DuplicateModuleException, ModuleNotProvidedException,
-            ModuleManager.ModuleNotFoundException {
-        String newTitle = "NEW";
-        String newCode = "CODE1";
-        Module editedMod = new Module(newCode);
-        editedMod.setTitle(newTitle);
-        ModuleManager.edit(editedMod, MOD_CODE_1);
+    void editMod_getCode_equalsNewCode()
+            throws DuplicateModuleException, ModuleNotProvidedException,
+            ModuleNotFoundException {
+        String newCode = "MA1512";
+        ModuleManager.edit(newCode, MOD_CODE_1);
 
-        assertEquals(newTitle, ModuleManager.getModule(newCode).getTitle());
+        assertEquals(newCode, ModuleManager.getModule(newCode).getModuleCode());
     }
 
     @Test
-    void deleteTask_getTaskCount_isEquals0() throws ModuleManager.ModuleNotFoundException {
+    void deleteTask_getTaskCount_isEquals0() throws ModuleNotFoundException {
         ModuleManager.delete(MOD_CODE_1);
         ModuleManager.delete(MOD_CODE_2);
 
         assertEquals(0, ModuleManager.getModCodeList().length);
-        assertThrows(ModuleManager.ModuleNotFoundException.class, () -> ModuleManager.getModule(MOD_CODE_1));
+        assertThrows(ModuleNotFoundException.class, () -> ModuleManager.getModule(MOD_CODE_1));
     }
 }

--- a/src/test/java/seedu/duke/data/TimeTableTest.java
+++ b/src/test/java/seedu/duke/data/TimeTableTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import seedu.duke.data.storage.InputOutputManager;
+import seedu.duke.exception.DuplicateModuleException;
 import seedu.duke.exception.LessonInvalidTimeException;
+import seedu.duke.exception.ModuleNotFoundException;
+import seedu.duke.exception.ModuleNotProvidedException;
 import seedu.duke.exception.TimeTableInitialiseException;
 
 import java.time.DayOfWeek;
@@ -32,12 +35,12 @@ public class TimeTableTest {
     static final int CURR_WEEK = now.get(ChronoField.ALIGNED_WEEK_OF_YEAR);
 
     @BeforeAll
-    static void setupUserMods() throws ModuleManager.DuplicateModuleException, ModuleManager.ModuleNotFoundException {
+    static void setupUserMods() throws DuplicateModuleException, ModuleNotProvidedException {
         InputOutputManager.loadNusModSave();
         ModuleManager.clearModules();
-        ModuleManager.add(new Module(MOD_CODE_1));
-        ModuleManager.add(new Module(MOD_CODE_2));
-        ModuleManager.add(new Module(MOD_CODE_3));
+        ModuleManager.add(MOD_CODE_1);
+        ModuleManager.add(MOD_CODE_2);
+        ModuleManager.add(MOD_CODE_3);
     }
 
     @BeforeEach
@@ -50,7 +53,7 @@ public class TimeTableTest {
     }
 
     @Test
-    void verify_addLesson_repeat1() throws LessonInvalidTimeException, ModuleManager.ModuleNotFoundException {
+    void verify_addLesson_repeat1() throws LessonInvalidTimeException, ModuleNotFoundException {
         TimeTableManager.addLesson(lesson1, 1);
 
         for (int i = CURR_WEEK; i < CURR_WEEK + 14; i++) {
@@ -65,7 +68,7 @@ public class TimeTableTest {
     }
 
     @Test
-    void verify_addLesson_repeat2() throws LessonInvalidTimeException, ModuleManager.ModuleNotFoundException {
+    void verify_addLesson_repeat2() throws LessonInvalidTimeException, ModuleNotFoundException {
         TimeTableManager.addLesson(lesson1, 2);
 
         for (int i = CURR_WEEK; i < CURR_WEEK + 14; i++) {
@@ -80,7 +83,7 @@ public class TimeTableTest {
     }
 
     @Test
-    void verify_addLesson_repeat3() throws LessonInvalidTimeException, ModuleManager.ModuleNotFoundException {
+    void verify_addLesson_repeat3() throws LessonInvalidTimeException, ModuleNotFoundException {
         TimeTableManager.addLesson(lesson1, 3);
 
         for (int i = CURR_WEEK; i < CURR_WEEK + 14; i++) {
@@ -95,7 +98,7 @@ public class TimeTableTest {
     }
 
     @Test
-    void verify_removeLesson_inSingleWeek() throws LessonInvalidTimeException, ModuleManager.ModuleNotFoundException {
+    void verify_removeLesson_inSingleWeek() throws LessonInvalidTimeException, ModuleNotFoundException {
         TimeTableManager.addLesson(lesson1, 1);
         TimeTableManager.addLesson(lesson2, 1);
         TimeTableManager.addLesson(lesson3, 1);
@@ -113,8 +116,7 @@ public class TimeTableTest {
     }
 
     @Test
-    void verify_removeLesson_overMultipleWeeks() throws LessonInvalidTimeException,
-            ModuleManager.ModuleNotFoundException {
+    void verify_removeLesson_overMultipleWeeks() throws LessonInvalidTimeException, ModuleNotFoundException {
         TimeTableManager.addLesson(lesson1, 1);
         TimeTableManager.addLesson(lesson2, 2);
         TimeTableManager.addLesson(lesson3, 3);

--- a/src/test/java/seedu/duke/parser/TimeTableCommandParserTest.java
+++ b/src/test/java/seedu/duke/parser/TimeTableCommandParserTest.java
@@ -10,7 +10,10 @@ import seedu.duke.data.Module;
 import seedu.duke.data.ModuleManager;
 import seedu.duke.data.TimeTableManager;
 import seedu.duke.data.storage.InputOutputManager;
+import seedu.duke.exception.DuplicateModuleException;
 import seedu.duke.exception.InvalidMatchException;
+import seedu.duke.exception.ModuleNotFoundException;
+import seedu.duke.exception.ModuleNotProvidedException;
 import seedu.duke.exception.TimeTableInitialiseException;
 import seedu.duke.util.ExceptionMessage;
 
@@ -52,10 +55,10 @@ public class TimeTableCommandParserTest {
             + DELETE_INDEX_2;
 
     @BeforeAll
-    static void setupUserMods() throws ModuleManager.DuplicateModuleException, ModuleManager.ModuleNotFoundException {
+    static void setupUserMods() throws DuplicateModuleException, ModuleNotProvidedException {
         InputOutputManager.loadNusModSave();
         ModuleManager.clearModules();
-        ModuleManager.add(new Module(MOD_CODE_1));
+        ModuleManager.add(MOD_CODE_1);
     }
 
     @BeforeEach


### PR DESCRIPTION
`ModuleNotProvidedException` and `ModuleNotFoundException` were swapped somehow inside ModuleManager's methods... Swapped both and also moved them to the Exception package instead of leaving them inside ModuleManager.

Changed `ModuleManager`'s `add` and `edit` to take module code strings instead of `Module` objects. This is because creating `Module` objects manually bypasses `ModuleManager`'s verification of module codes against NUSMods, leading to many errors. From now, `Module` objects should only be created by `ModuleManager`'s `add` method. 

This will fix #194, #179, #177, and #176.